### PR TITLE
feat(switch): add lively prop and default behavior

### DIFF
--- a/packages/components/switch/index.scss
+++ b/packages/components/switch/index.scss
@@ -4,6 +4,23 @@
   display: inline-flex;
   position: relative;
 
+  &-lively {
+    .fluent-switch__indicator {
+      font-size: 14px;
+      padding: 2px;
+      transition:
+        font-size 0.075s ease,
+        padding 0.075s ease;
+    }
+
+    .fluent-switch__input:not(:disabled):hover {
+      & ~ .fluent-switch__indicator {
+        font-size: 16px;
+        padding: 1px;
+      }
+    }
+  }
+
   &__input {
     top: 0;
     left: 0;
@@ -85,6 +102,17 @@
     }
   }
 
+  &-label-above {
+    flex-direction: column;
+  }
+
+  &-label-before {
+    & .fluent-switch__input {
+      right: 0;
+      left: unset;
+    }
+  }
+
   &__label {
     margin-top: calc((20px - var(--lineHeightBase300)) / 2);
     margin-bottom: calc((20px - var(--lineHeightBase300)) / 2);
@@ -121,9 +149,5 @@
       display: inline;
       line-height: 0;
     }
-  }
-
-  &-label-above {
-    flex-direction: column;
   }
 }

--- a/packages/components/switch/index.tsx
+++ b/packages/components/switch/index.tsx
@@ -60,6 +60,8 @@ export interface SwitchProps
    */
   label?: string;
 
+  lively?: boolean;
+
   disabled?: boolean;
   required?: boolean;
 }
@@ -68,7 +70,7 @@ const baseClassName = "fluent-switch";
 
 const Switch = (props: SwitchProps) => {
   const merged = mergeProps(
-    { indicator: <BiSolidCircle />, labelPosition: "after" },
+    { indicator: <BiSolidCircle />, labelPosition: "after", lively: true },
     props,
   );
 
@@ -93,6 +95,7 @@ const Switch = (props: SwitchProps) => {
         [`${baseClassName}-label-${merged.labelPosition}`]:
           merged.label && merged.labelPosition,
         [`${baseClassName}-disabled`]: merged.disabled,
+        [`${baseClassName}-lively`]: merged.lively,
         [`${merged.class}`]: merged.class,
       },
     });


### PR DESCRIPTION
- Introduced a new `lively` prop to the `SwitchProps` interface.
- Set the default value of `lively` to `true` in the `mergeProps` function.
- Added conditional class `fluent-switch-lively` based on the `lively` prop.

> [!NOTE]
> This feature is not an official feature of the Fluent React component library but has been added by referencing the native switch style in Windows 11.