### PR TITLE
feat(slider): add lively style and prop to slider component

### DIFF
--- a/packages/components/slider/index.scss
+++ b/packages/components/slider/index.scss
@@ -98,6 +98,21 @@
     }
   }
 
+  &.fluent-slider-lively {
+    .fluent-slider__thumb {
+      box-shadow: 0 0 0 calc(var(--fui-Slider__thumb--size) * 0.3)
+        var(--colorNeutralBackground1) inset;
+      transition: box-shadow 0.075s ease;
+    }
+
+    &:hover {
+      .fluent-slider__thumb {
+        box-shadow: 0 0 0 calc(var(--fui-Slider__thumb--size) * 0.2)
+          var(--colorNeutralBackground1) inset;
+      }
+    }
+  }
+
   &__thumb {
     --fui-Slider__thumb--position: clamp(
       var(--fui-Slider__inner-thumb--radius),

--- a/packages/components/slider/index.tsx
+++ b/packages/components/slider/index.tsx
@@ -65,12 +65,14 @@ export interface SliderProps
    * Triggers a callback when the value has been changed. This will be called on every individual step.
    */
   onChange?: (value: number) => void;
+
+  lively?: boolean;
 }
 
 const baseClassName = "fluent-slider";
 
 const Slider = (props: SliderProps) => {
-  const merged = mergeProps({ min: 0, max: 100 }, props);
+  const merged = mergeProps({ min: 0, max: 100, lively: true }, props);
 
   const [currentValue, setCurrentValue] = createSignal(
     props.value ?? props.defaultValue ?? merged.min,
@@ -95,6 +97,7 @@ const Slider = (props: SliderProps) => {
         [`${baseClassName}-vertical`]: merged.vertical,
         [`${baseClassName}-${merged.size}`]: merged.size,
         [`${baseClassName}-disabled`]: merged.disabled,
+        [`${baseClassName}-lively`]: merged.lively,
       },
     });
 


### PR DESCRIPTION
- Added a new `lively` prop to the `SliderProps` interface to enable lively styling.
- Updated the `Slider` component to conditionally apply the `fluent-slider-lively` class based on the `lively` prop.
- Added lively-specific styles to the `index.scss` file, including hover effects for the slider thumb.