### PR TITLE
feat(tooltip): improve positioning and add resize observer for dynamic adjustments

### DIFF
--- a/packages/components/tooltip/index.scss
+++ b/packages/components/tooltip/index.scss
@@ -4,6 +4,7 @@
   right: 0px;
   left: 0px;
   top: 0px;
+  margin: 0;
   line-height: var(--lineHeightBase300);
   font-weight: var(--fontWeightRegular);
   font-size: var(--fontSizeBase300);

--- a/packages/components/tooltip/index.tsx
+++ b/packages/components/tooltip/index.tsx
@@ -142,16 +142,28 @@ const Tooltip = (props: TooltipProps) => {
     const trigger = triggerRef!;
 
     if (tooltip && trigger) {
-      const calculatedPosition = calculatePosition(
-        trigger,
-        tooltip,
-        merged.positioning,
-      );
-      setPosition(calculatedPosition);
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          if (
+            entry.target === tooltip &&
+            tooltip.offsetWidth > 0 &&
+            tooltip.offsetHeight > 0
+          ) {
+            const calculatedPosition = calculatePosition(
+              trigger,
+              tooltip,
+              merged.positioning,
+            );
+            setPosition(calculatedPosition);
+          }
+        }
+      });
 
-      // Apply calculated position
-      //tooltip.style.top = `${calculatedPosition.top}px`;
-      //tooltip.style.left = `${calculatedPosition.left}px`;
+      resizeObserver.observe(tooltip);
+
+      onCleanup(() => {
+        resizeObserver.disconnect();
+      });
     }
   });
 
@@ -174,8 +186,6 @@ const Tooltip = (props: TooltipProps) => {
 
     // TODO: Show immediately if another tooltip is already visible
     //const delay = context.visibleTooltip ? 0 : state.showDelay;
-
-    calculatePosition(triggerRef!, tooltipRef!, merged.positioning);
 
     setDelayTimeout(() => {
       setVisible(true);
@@ -237,7 +247,9 @@ const Tooltip = (props: TooltipProps) => {
           <div
             ref={tooltipRef}
             role="tooltip"
-            style={{ left: `${position().left}px`, top: `${position().top}px` }}
+            style={{
+              transform: `translate3d(${position().left}px, ${position().top}px, 0)`,
+            }}
             class={`${baseClassName}__content`}
             data-popper-placement={merged.positioning}
           >

--- a/packages/components/tooltip/position.ts
+++ b/packages/components/tooltip/position.ts
@@ -5,7 +5,7 @@ export const calculatePosition = (
   tooltipElement: HTMLElement,
   positioning: PositioningShorthand,
 ) => {
-  const triggerRect = triggerElement.firstElementChild!.getBoundingClientRect();
+  const triggerRect = triggerElement.getBoundingClientRect();
   const tooltipRect = tooltipElement.getBoundingClientRect();
 
   let top = 0;
@@ -13,61 +13,75 @@ export const calculatePosition = (
 
   switch (positioning) {
     case "above":
-      top = triggerRect.top - tooltipRect.height - 8; // 8px gap
-      left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+      top = triggerRect.top - tooltipRect.height - 8; // 默认8px间距
+      left = triggerRect.left + (triggerRect.width - tooltipRect.width) / 2;
       break;
+
     case "above-start":
       top = triggerRect.top - tooltipRect.height - 8;
       left = triggerRect.left;
       break;
+
     case "above-end":
       top = triggerRect.top - tooltipRect.height - 8;
       left = triggerRect.right - tooltipRect.width;
       break;
+
     case "below":
       top = triggerRect.bottom + 8;
-      left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+      left = triggerRect.left + (triggerRect.width - tooltipRect.width) / 2;
       break;
+
     case "below-start":
       top = triggerRect.bottom + 8;
       left = triggerRect.left;
       break;
+
     case "below-end":
       top = triggerRect.bottom + 8;
       left = triggerRect.right - tooltipRect.width;
       break;
+
     case "before":
-      top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2;
+      top = triggerRect.top + (triggerRect.height - tooltipRect.height) / 2;
       left = triggerRect.left - tooltipRect.width - 8;
       break;
+
     case "before-top":
       top = triggerRect.top;
       left = triggerRect.left - tooltipRect.width - 8;
       break;
+
     case "before-bottom":
       top = triggerRect.bottom - tooltipRect.height;
       left = triggerRect.left - tooltipRect.width - 8;
       break;
+
     case "after":
-      top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2;
+      top = triggerRect.top + (triggerRect.height - tooltipRect.height) / 2;
       left = triggerRect.right + 8;
       break;
+
     case "after-top":
       top = triggerRect.top;
       left = triggerRect.right + 8;
       break;
+
     case "after-bottom":
       top = triggerRect.bottom - tooltipRect.height;
       left = triggerRect.right + 8;
       break;
+
+    default:
+      top = triggerRect.top - tooltipRect.height - 8;
+      left = triggerRect.left + (triggerRect.width - tooltipRect.width) / 2;
   }
 
-  // Ensure tooltip stays within viewport
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
+  const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+  const scrollTop = window.scrollY || document.documentElement.scrollTop;
 
-  left = Math.max(10, Math.min(left, viewportWidth - tooltipRect.width - 10));
-  top = Math.max(10, Math.min(top, viewportHeight - tooltipRect.height - 10));
-
-  return { top, left };
+  return {
+    top: top - scrollTop,
+    left: left - scrollLeft,
+  };
 };


### PR DESCRIPTION
- Added `margin: 0` to the tooltip's root styles in `index.scss`.
- Introduced a `ResizeObserver` to dynamically recalculate and adjust the tooltip's position when its size changes.
- Updated the `calculatePosition` function to handle positioning more accurately, including adjustments for scroll positions.
- Modified the tooltip's inline styles to use `transform: translate3d` for smoother positioning.
- Removed redundant `calculatePosition` calls and optimized the positioning logic.