### PR TITLE
style(Input): Add focus-within styles to input component

### DIFF
--- a/packages/components/input/index.scss
+++ b/packages/components/input/index.scss
@@ -68,6 +68,14 @@
     border-right-style: none;
     border-top-style: none;
     border-radius: 0px;
+
+    &:focus-within {
+      &::after {
+        right: 0;
+        left: 0;
+        border-radius: 0;
+      }
+    }
   }
 
   &-filled {


### PR DESCRIPTION
- Added `:focus-within` pseudo-class to the input component's styles.
- Updated the `::after` pseudo-element to adjust `right`, `left`, and `border-radius` properties when the input is focused.