### PR TITLE
fix(Button): restore missing appearance class in Button component

### DIFF
--- a/packages/components/button/index.tsx
+++ b/packages/components/button/index.tsx
@@ -84,6 +84,7 @@ const Button = (props: ButtonProps) => {
         [`${merged.class}`]: merged.class,
         [`${baseClassName}-disabled`]: disabled(),
         [`${baseClassName}-${merged.shape}`]: merged.shape,
+        [`${baseClassName}-${merged.appearance}`]: merged.appearance,
         [`${baseClassName}-${merged.size}`]: merged.size,
         [`${baseClassName}-icon-only`]: iconOnly(),
       },


### PR DESCRIPTION
Fix the issue where the `${baseClassName}-${merged.appearance}` class was missing in the previous version of the Button component.