### PR TITLE
chore(tooltip): Refactor TooltipDemo and add withArrow prop

### DIFF
--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -1,3 +1,4 @@
+import { BiRegularSlider } from "solid-icons/bi";
 import {
   TbArrowCurveLeft,
   TbArrowCurveRight,
@@ -79,7 +80,23 @@ const TooltipGrid = (props: { withArrow?: boolean }) => {
 const TooltipDemo = () => (
   <div>
     <TooltipGrid />
+
     <TooltipGrid withArrow />
+
+    <Tooltip
+      content={{
+        children: "Example tooltip",
+        style: {
+          "background-color": "var(--colorBrandBackground)",
+          color: "var(--colorNeutralForegroundInverted)",
+        },
+      }}
+      positioning="after"
+      withArrow
+      relationship="label"
+    >
+      <Button icon={<BiRegularSlider />} />
+    </Tooltip>
   </div>
 );
 

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -7,8 +7,8 @@ import { For } from "solid-js";
 import Tooltip from "~/components/tooltip";
 import { Button } from "~/index";
 
-const TooltipDemo = () => {
-  const positions = [
+const positions = () =>
+  [
     ["above-start", <TbArrowCurveLeft />],
     ["above", <TbArrowNarrowUp />],
     ["above-end", <TbArrowCurveRight />],
@@ -26,6 +26,7 @@ const TooltipDemo = () => {
     ["below-end", <TbArrowCurveLeft style={{ rotate: "180deg" }} />],
   ] as const;
 
+const TooltipGrid = (props: { withArrow?: boolean }) => {
   return (
     <div
       style={{
@@ -50,14 +51,23 @@ const TooltipDemo = () => {
             '".             below-start   below         below-end     .            "',
         }}
       >
-        <For each={positions}>
+        <For each={positions()}>
           {([position, icon]) => (
             <Tooltip
               positioning={position}
               relationship="label"
               content={`This is ${position} tooltip`}
+              withArrow={props.withArrow}
             >
-              <Button style={{ "grid-area": position }} icon={icon} />
+              <Button
+                style={{
+                  "grid-area": position,
+                  width: "64px",
+                  height: "64px",
+                  "max-width": "64px",
+                }}
+                icon={icon}
+              />
             </Tooltip>
           )}
         </For>
@@ -65,5 +75,12 @@ const TooltipDemo = () => {
     </div>
   );
 };
+
+const TooltipDemo = () => (
+  <div>
+    <TooltipGrid />
+    <TooltipGrid withArrow />
+  </div>
+);
 
 export default TooltipDemo;


### PR DESCRIPTION
- Extracted `positions` array into a separate function for reusability.
- Introduced `TooltipGrid` component to handle the grid layout and tooltip rendering.
- Added `withArrow` prop to `TooltipGrid` to control the display of tooltip arrows.
- Updated button styles within `TooltipGrid` to ensure consistent sizing.
- Modified `TooltipDemo` to render two `TooltipGrid` instances, one with arrows and one without.