### PR TITLE
feat(tooltip): enhance positioning logic with viewport boundary checks

### DIFF
--- a/packages/components/tooltip/index.tsx
+++ b/packages/components/tooltip/index.tsx
@@ -137,6 +137,7 @@ const Tooltip = (props: TooltipProps) => {
     props,
   );
 
+  const [positioning, setPositioning] = createSignal(merged.positioning);
   const [tooltipOffset, setTooltipOffset] = createSignal({ top: 0, left: 0 });
   const [arrowOffset, setArrowOffset] = createSignal<OffsetNullable>({});
   const [visible, setVisible] = createSignal(merged.visible);
@@ -162,13 +163,14 @@ const Tooltip = (props: TooltipProps) => {
             tooltipElement.offsetWidth > 0 &&
             tooltipElement.offsetHeight > 0
           ) {
-            const { tooltip, arrow } = calculateOffsets(
+            const { tooltip, arrow, finalPositioning } = calculateOffsets(
               triggerElement,
               tooltipElement,
               merged.positioning,
             );
             setTooltipOffset(tooltip);
             setArrowOffset(arrow);
+            setPositioning(finalPositioning);
           }
         }
       });
@@ -291,7 +293,7 @@ const Tooltip = (props: TooltipProps) => {
                 merged.content.class
               ),
             }}
-            data-popper-placement={merged.positioning}
+            data-popper-placement={positioning()}
           >
             <Show when={merged.withArrow}>
               <div


### PR DESCRIPTION
- Added `positioning` state to track the final tooltip position
- Introduced `VIEWPORT_PADDING` constant to ensure tooltip stays within viewport boundaries
- Implemented `POSITION_MIRRORS` mapping for automatic position flipping
- Added `doesTooltipFitViewport` utility to check if tooltip fits within viewport
- Updated `calculateOffsets` to return `finalPositioning` and handle automatic position flipping when tooltip exceeds viewport boundaries
- Modified tooltip component to use dynamic positioning state instead of static prop value