### PR TITLE
feat(card): add Card component and related subcomponents

### DIFF
--- a/packages/components/card/Card/index.scss
+++ b/packages/components/card/Card/index.scss
@@ -1,0 +1,28 @@
+.fluent-card {
+  --fui-Card--border-radius: var(--borderRadiusMedium);
+  --fui-Card--size: 12px;
+
+  flex-direction: column;
+  max-width: 100%;
+  box-shadow: var(--shadow4);
+  background-color: var(--colorNeutralBackground1);
+  margin: auto;
+  overflow: hidden;
+  border-radius: var(--fui-Card--border-radius);
+  padding: var(--fui-Card--size);
+  gap: var(--fui-Card--size);
+  display: flex;
+  position: relative;
+  box-sizing: border-box;
+  color: var(--colorNeutralForeground1);
+
+  &-small {
+    --fui-Card--border-radius: var(--borderRadiusSmall);
+    --fui-Card--size: 8px;
+  }
+
+  &-large {
+    --fui-Card--border-radius: var(--borderRadiusLarge);
+    --fui-Card--size: 16px;
+  }
+}

--- a/packages/components/card/Card/index.tsx
+++ b/packages/components/card/Card/index.tsx
@@ -1,0 +1,46 @@
+import type { JSX } from "solid-js";
+
+import { addClassList } from "~/utils";
+
+import type { CardProps } from "./types";
+
+import "./index.scss";
+import { mergeProps } from "solid-js";
+
+const baseClassName = "fluent-card";
+
+export const Card = (
+  props: CardProps & JSX.HTMLSlotElementAttributes<HTMLDivElement>,
+) => {
+  const merged = mergeProps(
+    {
+      appearance: "filled",
+      focusMode: "off",
+      orientation: "vertical",
+      size: "medium",
+      selected: false,
+      defaultSelected: false,
+    } as CardProps,
+    props,
+  );
+
+  const classList = () =>
+    addClassList({
+      base: baseClassName,
+      others: {
+        [`${merged.class}`]: merged.class,
+        [`${baseClassName}-focus-mode`]: merged.focusMode,
+        [`${baseClassName}-${merged.size}`]: merged.size,
+        [`${baseClassName}-${merged.orientation}`]: merged.orientation,
+        [`${baseClassName}-selected`]:
+          merged.defaultSelected ?? merged.selected,
+        [`${baseClassName}-${merged.appearance}`]: merged.appearance,
+        [`${baseClassName}-${merged.size}`]: merged.size,
+      },
+    });
+  return (
+    <div {...merged} classList={classList()}>
+      {props.children}
+    </div>
+  );
+};

--- a/packages/components/card/Card/types.ts
+++ b/packages/components/card/Card/types.ts
@@ -1,0 +1,98 @@
+import type { JSX } from "solid-js";
+
+/**
+ * Data sent from the selection events on a selectable card.
+ */
+export type CardOnSelectData = {
+  selected: boolean;
+};
+
+/**
+ * Card component props.
+ */
+export interface CardProps {
+  /**
+   * Sets the appearance of the card.
+   *
+   * `filled`
+   * The card will have a shadow, border and background color.
+   *
+   * `filled-alternative`
+   * This appearance is similar to `filled`, but the background color will be a little darker.
+   *
+   * `outline`
+   * This appearance is similar to `filled`, but the background color will be transparent and no shadow applied.
+   *
+   * `subtle`
+   * This appearance is similar to `filled-alternative`, but no border is applied.
+   *
+   * @default 'filled'
+   */
+  appearance?: "filled" | "filled-alternative" | "outline" | "subtle";
+
+  /**
+   * Sets the focus behavior for the card.
+   *
+   * `off`
+   * The card will not focusable.
+   *
+   * `no-tab`
+   * This behaviour traps the focus inside of the Card when pressing the Enter key and will only release focus when
+   * pressing the Escape key.
+   *
+   * `tab-exit`
+   * This behaviour traps the focus inside of the Card when pressing the Enter key but will release focus when pressing
+   * the Tab key on the last inner element.
+   *
+   * `tab-only`
+   * This behaviour will cycle through all elements inside of the Card when pressing the Tab key and then release focus
+   * after the last inner element.
+   *
+   * @default 'off'
+   */
+  focusMode?: "off" | "no-tab" | "tab-exit" | "tab-only";
+
+  /**
+   * Defines the orientation of the card.
+   *
+   * @default 'vertical'
+   */
+  orientation?: "horizontal" | "vertical";
+
+  /**
+   * Controls the card's border radius and padding between inner elements.
+   *
+   * @default 'medium'
+   */
+  size?: "small" | "medium" | "large";
+
+  /**
+   * Defines the controlled selected state of the card.
+   *
+   * @default false
+   */
+  selected?: boolean;
+
+  /**
+   * Defines whether the card is initially in a selected state when rendered.
+   *
+   * @default false
+   */
+  defaultSelected?: boolean;
+
+  /**
+   * Callback to be called when the selected state value changes.
+   */
+  onSelectionChange?: (data: CardOnSelectData) => void;
+
+  /**
+   * Floating action that can be rendered on the top-right of a card. Often used together with
+   * `selected`, `defaultSelected`, and `onSelectionChange` props
+   */
+  floatingAction?: JSX.Element;
+
+  /**
+   * The internal checkbox element that renders when the card is selectable.
+   */
+  checkbox?: JSX.Element;
+}

--- a/packages/components/card/CardFooter/index.scss
+++ b/packages/components/card/CardFooter/index.scss
@@ -1,0 +1,6 @@
+.fluent-card-footer {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}

--- a/packages/components/card/CardFooter/index.tsx
+++ b/packages/components/card/CardFooter/index.tsx
@@ -1,0 +1,11 @@
+import type { ParentProps } from "solid-js";
+
+import type { CardFooterProps } from "./types";
+
+import "./index.scss";
+
+const baseClassName = "fluent-card-footer";
+
+export const CardFooter = (props: ParentProps<CardFooterProps>) => (
+  <div class={baseClassName}>{props.children}</div>
+);

--- a/packages/components/card/CardFooter/types.ts
+++ b/packages/components/card/CardFooter/types.ts
@@ -1,0 +1,8 @@
+import type { JSX } from "solid-js";
+
+export interface CardFooterProps {
+  /**
+   * Container that renders on the far end of the footer, used for action buttons.
+   */
+  action?: JSX.Element;
+}

--- a/packages/components/card/CardHeader/index.scss
+++ b/packages/components/card/CardHeader/index.scss
@@ -1,0 +1,33 @@
+.fluent-card-header {
+  --fui-CardHeader--gap: 12px;
+
+  flex-shrink: 0;
+  grid-auto-columns: min-content 1fr min-content;
+  align-items: center;
+  display: grid;
+
+  &__image {
+    grid-row-start: span 2;
+    grid-column-start: 1;
+    margin-right: var(--fui-CardHeader--gap);
+    display: inline-flex;
+  }
+
+  &__header {
+    grid-row-start: 1;
+    grid-column-start: 2;
+    display: flex;
+  }
+
+  &__description {
+    grid-row-start: 2;
+    grid-column-start: 2;
+    display: flex;
+  }
+
+  &__action {
+    grid-column-start: 3;
+    grid-row-start: span 2;
+    margin-left: var(--fui-CardHeader--gap);
+  }
+}

--- a/packages/components/card/CardHeader/index.tsx
+++ b/packages/components/card/CardHeader/index.tsx
@@ -1,0 +1,24 @@
+import { children } from "solid-js";
+
+import type { CardHeaderProps } from "./types";
+
+import "./index.scss";
+
+const baseClassName = "fluent-card-header";
+
+export const CardHeader = (props: CardHeaderProps) => {
+  const action = children(
+    () =>
+      props.action && (
+        <div class={`${baseClassName}__action`}>{props.action}</div>
+      ),
+  );
+  return (
+    <div class={baseClassName}>
+      <div class={`${baseClassName}__image`}>{props.image}</div>
+      <div class={`${baseClassName}__header`}>{props.header}</div>
+      <div class={`${baseClassName}__description`}>{props.description}</div>
+      {action()}
+    </div>
+  );
+};

--- a/packages/components/card/CardHeader/types.ts
+++ b/packages/components/card/CardHeader/types.ts
@@ -1,0 +1,23 @@
+import type { JSX } from "solid-js";
+
+export interface CardHeaderProps {
+  /**
+   * Element used to render an image or avatar related to the card.
+   */
+  image: JSX.Element;
+
+  /**
+   * Element used to render the main header title.
+   */
+  header: JSX.Element;
+
+  /**
+   * Element used to render short descriptions related to the title.
+   */
+  description: JSX.Element;
+
+  /**
+   * Container that renders on the far end of the footer, used for action buttons.
+   */
+  action?: JSX.Element;
+}

--- a/packages/components/card/CardPreview/index.scss
+++ b/packages/components/card/CardPreview/index.scss
@@ -1,0 +1,13 @@
+.fluent-card-preview {
+  margin-right: calc(var(--fui-Card--size) * -1);
+  margin-left: calc(var(--fui-Card--size) * -1);
+  position: relative;
+
+  &__logo {
+    height: 32px;
+    width: 32px;
+    left: 12px;
+    bottom: 12px;
+    position: absolute;
+  }
+}

--- a/packages/components/card/CardPreview/index.tsx
+++ b/packages/components/card/CardPreview/index.tsx
@@ -1,0 +1,20 @@
+import { children, type ParentProps } from "solid-js";
+
+import type { CardPreviewProps } from "./types";
+
+import "./index.scss";
+
+const baseClassName = "fluent-card-preview";
+
+export const CardPreview = (props: ParentProps<CardPreviewProps>) => {
+  const logo = children(
+    () =>
+      props.logo && <div class={`${baseClassName}__logo`}>{props.logo}</div>,
+  );
+  return (
+    <div class={baseClassName}>
+      {props.children}
+      {logo()}
+    </div>
+  );
+};

--- a/packages/components/card/CardPreview/types.ts
+++ b/packages/components/card/CardPreview/types.ts
@@ -1,0 +1,8 @@
+import type { JSX } from "solid-js";
+
+export interface CardPreviewProps {
+  /**
+   * Container that holds a logo related to the image preview provided.
+   */
+  logo?: JSX.Element;
+}

--- a/packages/components/card/index.ts
+++ b/packages/components/card/index.ts
@@ -1,0 +1,9 @@
+export { Card } from "./Card";
+export { CardFooter } from "./CardFooter";
+export { CardHeader } from "./CardHeader";
+export { CardPreview } from "./CardPreview";
+
+export type { CardProps } from "./Card/types";
+export type { CardFooterProps } from "./CardFooter/types";
+export type { CardHeaderProps } from "./CardHeader/types";
+export type { CardPreviewProps } from "./CardPreview/types";

--- a/packages/components/text/index.ts
+++ b/packages/components/text/index.ts
@@ -1,0 +1,2 @@
+export { Body1 } from "./presets/Body1";
+export { Caption1 } from "./presets/Caption1";

--- a/packages/components/text/presets/Body1/index.tsx
+++ b/packages/components/text/presets/Body1/index.tsx
@@ -1,0 +1,11 @@
+import type { ParentProps } from "solid-js";
+
+import { typographyStyles } from "~/styles/global";
+
+const baseClassName = "fluent-body1";
+
+export const Body1 = (props: ParentProps) => (
+  <div class={baseClassName} style={typographyStyles.body1}>
+    {props.children}
+  </div>
+);

--- a/packages/components/text/presets/Caption1/index.tsx
+++ b/packages/components/text/presets/Caption1/index.tsx
@@ -1,0 +1,10 @@
+import type { ParentProps } from "solid-js";
+import { typographyStyles } from "~/styles/global";
+
+const baseClassName = "fluent-caption1";
+
+export const Caption1 = (props: ParentProps) => (
+  <div class={baseClassName} style={typographyStyles.caption1}>
+    {props.children}
+  </div>
+);

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -30,4 +30,8 @@ export type { BadgeProps } from "./components/badge";
 export { default as Tooltip } from "./components/tooltip";
 export type { TooltipProps } from "./components/tooltip";
 
+export { Card, CardHeader, CardFooter, CardPreview } from "./components/card";
+
+export { Body1, Caption1 } from "./components/text";
+
 export * from "./utils";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ const examples = [
   lazy(() => import("./components/slider")),
   lazy(() => import("./components/badge")),
   lazy(() => import("./components/tooltip")),
+  lazy(() => import("./components/card")),
 ];
 
 //const menus = ["Button"];

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,0 +1,49 @@
+import { FaSolidReply, FaSolidShare } from "solid-icons/fa";
+import Button from "~/components/button";
+import { Card, CardFooter, CardHeader, CardPreview } from "~/components/card";
+import { Caption1 } from "~/components/text";
+import { Body1 } from "~/index";
+
+const Cards = () => (
+  <div>
+    <div style={{ padding: "20px" }}>
+      <Card style={{ width: "720px" }}>
+        <CardHeader
+          image={
+            <img
+              src="https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card/stories/src/assets/avatar_elvia.svg"
+              alt="Elvia Atkins avatar picture"
+            />
+          }
+          header={
+            <Body1>
+              <b>Elvia Atkins</b> mentioned you
+            </Body1>
+          }
+          description={<Caption1>5h ago · About us - Overview</Caption1>}
+        />
+
+        <CardPreview
+          logo={
+            <img
+              src="https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card/stories/src/assets/docx.png"
+              alt="Microsoft Word document"
+            />
+          }
+        >
+          <img
+            src="https://raw.githubusercontent.com/microsoft/fluentui/master/packages/react-components/react-card/stories/src/assets/doc_template.png"
+            alt="Preview of a Word document: About Us - Overview"
+          />
+        </CardPreview>
+
+        <CardFooter>
+          <Button icon={<FaSolidReply />}>Reply</Button>
+          <Button icon={<FaSolidShare />}>Share</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  </div>
+);
+
+export default Cards;


### PR DESCRIPTION
- Introduced the `Card` component with support for different appearances, focus modes, orientations, and sizes.
- Added `CardHeader`, `CardFooter`, and `CardPreview` subcomponents to structure card content.
- Included SCSS styles for each component to ensure consistent styling.
- Exported all card-related components and types from the main index file.
- Added a demo example in `src/components/card.tsx` to showcase the card component in action.
- Updated the main `packages/index.ts` to export the new card components.