### PR TITLE
refactor(card): enhance component structure and props handling

### DIFF
--- a/packages/components/card/Card/index.tsx
+++ b/packages/components/card/Card/index.tsx
@@ -1,11 +1,11 @@
 import type { JSX } from "solid-js";
+import { mergeProps, splitProps } from "solid-js";
 
 import { addClassList } from "~/utils";
 
 import type { CardProps } from "./types";
 
 import "./index.scss";
-import { mergeProps } from "solid-js";
 
 const baseClassName = "fluent-card";
 
@@ -38,9 +38,24 @@ export const Card = (
         [`${baseClassName}-${merged.size}`]: merged.size,
       },
     });
+
+  const [local, others] = splitProps(merged, [
+    "class",
+    "children",
+    "appearance",
+    "focusMode",
+    "orientation",
+    "size",
+    "selected",
+    "defaultSelected",
+    "onSelectionChange",
+    "floatingAction",
+    "checkbox",
+  ]);
+
   return (
-    <div {...merged} classList={classList()}>
-      {props.children}
+    <div {...others} classList={classList()}>
+      {local.children}
     </div>
   );
 };

--- a/packages/components/card/CardFooter/index.tsx
+++ b/packages/components/card/CardFooter/index.tsx
@@ -1,4 +1,6 @@
-import type { ParentProps } from "solid-js";
+import { splitProps, type JSX, type ParentProps } from "solid-js";
+
+import { addClassList } from "~/utils";
 
 import type { CardFooterProps } from "./types";
 
@@ -6,6 +8,23 @@ import "./index.scss";
 
 const baseClassName = "fluent-card-footer";
 
-export const CardFooter = (props: ParentProps<CardFooterProps>) => (
-  <div class={baseClassName}>{props.children}</div>
-);
+export const CardFooter = (
+  props: ParentProps<CardFooterProps> &
+    JSX.HTMLSlotElementAttributes<HTMLDivElement>,
+) => {
+  const [local, others] = splitProps(props, ["children", "class"]);
+
+  const classList = () =>
+    addClassList({
+      base: baseClassName,
+      others: {
+        [`${local.class}`]: local.class,
+      },
+    });
+
+  return (
+    <div {...others} classList={classList()}>
+      {local.children}
+    </div>
+  );
+};

--- a/packages/components/card/CardHeader/index.tsx
+++ b/packages/components/card/CardHeader/index.tsx
@@ -1,4 +1,6 @@
-import { children } from "solid-js";
+import { children, splitProps, type JSX } from "solid-js";
+
+import { addClassList } from "~/utils";
 
 import type { CardHeaderProps } from "./types";
 
@@ -6,18 +8,36 @@ import "./index.scss";
 
 const baseClassName = "fluent-card-header";
 
-export const CardHeader = (props: CardHeaderProps) => {
+export const CardHeader = (
+  props: CardHeaderProps & JSX.HTMLSlotElementAttributes<HTMLDivElement>,
+) => {
+  const [local, others] = splitProps(props, [
+    "class",
+    "action",
+    "image",
+    "header",
+    "description",
+  ]);
+
+  const classList = () =>
+    addClassList({
+      base: baseClassName,
+      others: {
+        [`${local.class}`]: local.class,
+      },
+    });
+
   const action = children(
     () =>
-      props.action && (
-        <div class={`${baseClassName}__action`}>{props.action}</div>
+      local.action && (
+        <div class={`${baseClassName}__action`}>{local.action}</div>
       ),
   );
   return (
-    <div class={baseClassName}>
-      <div class={`${baseClassName}__image`}>{props.image}</div>
-      <div class={`${baseClassName}__header`}>{props.header}</div>
-      <div class={`${baseClassName}__description`}>{props.description}</div>
+    <div {...others} classList={classList()}>
+      <div class={`${baseClassName}__image`}>{local.image}</div>
+      <div class={`${baseClassName}__header`}>{local.header}</div>
+      <div class={`${baseClassName}__description`}>{local.description}</div>
       {action()}
     </div>
   );

--- a/packages/components/card/CardPreview/index.tsx
+++ b/packages/components/card/CardPreview/index.tsx
@@ -1,4 +1,7 @@
-import { children, type ParentProps } from "solid-js";
+import { children, splitProps } from "solid-js";
+import type { JSX, ParentProps } from "solid-js";
+
+import { addClassList } from "~/utils";
 
 import type { CardPreviewProps } from "./types";
 
@@ -6,14 +9,27 @@ import "./index.scss";
 
 const baseClassName = "fluent-card-preview";
 
-export const CardPreview = (props: ParentProps<CardPreviewProps>) => {
+export const CardPreview = (
+  props: ParentProps<CardPreviewProps> &
+    JSX.HTMLSlotElementAttributes<HTMLDivElement>,
+) => {
+  const [local, others] = splitProps(props, ["class", "children", "logo"]);
+
+  const classList = () =>
+    addClassList({
+      base: baseClassName,
+      others: {
+        [`${local.class}`]: local.class,
+      },
+    });
+
   const logo = children(
     () =>
-      props.logo && <div class={`${baseClassName}__logo`}>{props.logo}</div>,
+      local.logo && <div class={`${baseClassName}__logo`}>{local.logo}</div>,
   );
   return (
-    <div class={baseClassName}>
-      {props.children}
+    <div {...others} classList={classList()}>
+      {local.children}
       {logo()}
     </div>
   );


### PR DESCRIPTION
- Refactor `Card`, `CardFooter`, `CardHeader`, and `CardPreview` components to use `splitProps` for better props management.
- Add `addClassList` utility for consistent class handling across components.
- Improve type safety by extending `JSX.HTMLSlotElementAttributes<HTMLDivElement>`.
- Ensure proper separation of local and other props for cleaner and more maintainable code.