### PR TITLE
ci(publish): disable failOnError in changelog generation step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           configuration: ".github/changelog-configuration.json"
           toTag: "refs/heads/main"
-          failOnError: true
+          failOnError: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Disabling failOnError to prevent workflow failures when changelog generation encounters non-critical issues, ensuring smoother CI pipeline execution.