### PR TITLE
chore: make package publicly accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-solid",
-  "private": true,
+  "private": false,
   "version": "0.2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Set the `private` field to `false` in package.json to allow the package to be published and accessed publicly.