### PR TITLE
refactor(text): change Text component export to default and lazy load

### DIFF
--- a/packages/components/text/Text/Text.tsx
+++ b/packages/components/text/Text/Text.tsx
@@ -5,7 +5,7 @@ import type { RequiredTextProps, TextProps } from "./Text.types";
 import * as styles from "./Text.css";
 import { Dynamic } from "solid-js/web";
 
-export const Text = (props: TextProps) => {
+const Text = (props: TextProps) => {
   const merged = mergeProps(
     {
       as: "span",
@@ -59,3 +59,5 @@ export const Text = (props: TextProps) => {
 
   return <Dynamic component={local.as} {...others} classList={classList()} />;
 };
+
+export default Text;

--- a/packages/components/text/Text/index.ts
+++ b/packages/components/text/Text/index.ts
@@ -1,2 +1,2 @@
-export { Text } from "./Text";
+export { default as Text } from "./Text";
 export type { TextProps } from "./Text.types";

--- a/packages/components/text/presets/createPreset.tsx
+++ b/packages/components/text/presets/createPreset.tsx
@@ -1,5 +1,7 @@
-import { Text } from "../Text";
+import { lazy } from "solid-js";
 import type { TextPresetProps } from "../Text/Text.types";
+
+const Text = lazy(() => import("../Text/Text"));
 
 export const createPreset = (
   classList:


### PR DESCRIPTION
Switch Text component to default export for consistency and implement lazy loading in presets to improve performance by reducing initial bundle size