### PR TITLE
refactor(组件): 统一组件导出方式为默认导出并优化类型定义

### DIFF
--- a/packages/components/badge/Badge.tsx
+++ b/packages/components/badge/Badge.tsx
@@ -2,7 +2,7 @@ import { mergeProps, children, Show, splitProps } from "solid-js";
 import type { BadgeProps } from "./Badge.types";
 import { badge, size, appearance, shape, color, icon } from "./Badge.css";
 
-const Badge = (props: BadgeProps) => {
+export const Badge = (props: BadgeProps) => {
   const merged = mergeProps(
     {
       size: "medium" as NonNullable<BadgeProps["size"]>,
@@ -54,5 +54,3 @@ const Badge = (props: BadgeProps) => {
     </div>
   );
 };
-
-export default Badge;

--- a/packages/components/badge/index.ts
+++ b/packages/components/badge/index.ts
@@ -1,2 +1,2 @@
-export { default as Badge } from "./Badge";
+export { Badge as default } from "./Badge";
 export type { BadgeProps } from "./Badge.types";

--- a/packages/components/button/Button.css.ts
+++ b/packages/components/button/Button.css.ts
@@ -7,105 +7,12 @@ import {
 import { themeContract } from "~/themes/theme.css";
 import { vars } from "~/themes/var.css";
 
-// Create icon spacing variable
-export const iconSpacing = createVar();
-
-// Icon style
-const iconStyle = style({
-  vars: {
-    [iconSpacing]: vars.spacingHorizontalSNudge,
-  },
-  alignItems: "center",
-  display: "inline-flex",
-  justifyContent: "center",
-  fontSize: "20px",
-  height: "20px",
-  width: "20px",
-});
-
-const iconBeforeStyle = style({
-  marginRight: iconSpacing,
-});
-
-const iconAfterStyle = style({
-  marginLeft: iconSpacing,
-});
-
-// Icon-only button style
-const iconOnlyStyle = style({
-  minWidth: "32px",
-  maxWidth: "32px",
-  padding: "5px",
-});
-
-globalStyle(`${iconOnlyStyle} ${iconStyle}`, {
-  margin: 0,
-});
-
-// Small icon-only button
-const smallIconOnlyStyle = style({
-  minWidth: "24px",
-  maxWidth: "24px",
-});
-
-// Large icon-only button
-const largeIconOnlyStyle = style({
-  minWidth: "40px",
-  maxWidth: "40px",
-});
-
-// Small icon spacing
-const smallIconSpacingStyle = style({
-  vars: {
-    [iconSpacing]: vars.spacingHorizontalXS,
-  },
-});
-
-// Large icon spacing
-const largeIconSpacingStyle = style({
-  vars: {
-    [iconSpacing]: vars.spacingHorizontalSNudge,
-  },
-});
-
-// Base button style
-const baseButton = style({
-  alignItems: "center",
-  boxSizing: "border-box",
-  display: "inline-flex",
-  justifyContent: "center",
-  textDecorationLine: "none",
-  verticalAlign: "middle",
-  margin: "0px",
-  overflow: "hidden",
-  border: `${vars.strokeWidthThin} solid ${themeContract.colorNeutralStroke1}`,
-  fontFamily: vars.fontFamilyBase,
-  outlineStyle: "none",
-  padding: `5px ${vars.spacingHorizontalM}`,
-  borderRadius: vars.borderRadiusMedium,
-  fontSize: vars.fontSizeBase300,
-  fontWeight: vars.fontWeightSemibold,
-  lineHeight: vars.lineHeightBase300,
-  transitionDuration: vars.durationFaster,
-  transitionProperty: "background, border, color",
-  transitionTimingFunction: vars.curveEasyEase,
-
-  selectors: {
-    "&:disabled": {
-      cursor: "not-allowed",
-    },
-
-    [`&:not(${iconOnlyStyle})`]: {
-      minWidth: "96px",
-    },
-  },
-});
-
 // Button variants by appearance
 const appearanceVariants = styleVariants({
   secondary: {
     backgroundColor: themeContract.colorNeutralBackground1,
     color: themeContract.colorNeutralForeground1,
+    border: `${vars.strokeWidthThin} solid ${themeContract.colorNeutralStroke1}`,
 
     selectors: {
       "&:disabled": {
@@ -220,6 +127,115 @@ const appearanceVariants = styleVariants({
         color: themeContract.colorNeutralForegroundOnBrand,
         borderColor: themeContract.colorTransparentStroke,
       },
+    },
+  },
+});
+
+// Create icon spacing variable
+export const iconSpacing = createVar();
+
+// Icon style
+const iconStyle = style({
+  vars: {
+    [iconSpacing]: vars.spacingHorizontalSNudge,
+  },
+  alignItems: "center",
+  display: "inline-flex",
+  justifyContent: "center",
+  fontSize: "20px",
+  height: "20px",
+  width: "20px",
+
+  selectors: {
+    [`${appearanceVariants.subtle} &`]: {
+      color: themeContract.colorNeutralForeground2,
+    },
+
+    [`${appearanceVariants.subtle}:not(:disabled):hover &`]: {
+      color: themeContract.colorNeutralForeground2BrandHover,
+      backgroundColor: themeContract.colorSubtleBackgroundHover,
+    },
+
+    [`${appearanceVariants.subtle}:not(:disabled):hover:active &`]: {
+      color: themeContract.colorNeutralForeground2BrandPressed,
+      backgroundColor: themeContract.colorSubtleBackgroundPressed,
+    },
+  },
+});
+
+const iconBeforeStyle = style({
+  marginRight: iconSpacing,
+});
+
+const iconAfterStyle = style({
+  marginLeft: iconSpacing,
+});
+
+// Icon-only button style
+const iconOnlyStyle = style({
+  minWidth: "32px",
+  maxWidth: "32px",
+  padding: "5px",
+});
+
+globalStyle(`${iconOnlyStyle} ${iconStyle}`, {
+  margin: 0,
+});
+
+// Small icon-only button
+const smallIconOnlyStyle = style({
+  minWidth: "24px",
+  maxWidth: "24px",
+});
+
+// Large icon-only button
+const largeIconOnlyStyle = style({
+  minWidth: "40px",
+  maxWidth: "40px",
+});
+
+// Small icon spacing
+const smallIconSpacingStyle = style({
+  vars: {
+    [iconSpacing]: vars.spacingHorizontalXS,
+  },
+});
+
+// Large icon spacing
+const largeIconSpacingStyle = style({
+  vars: {
+    [iconSpacing]: vars.spacingHorizontalSNudge,
+  },
+});
+
+// Base button style
+const baseButton = style({
+  alignItems: "center",
+  boxSizing: "border-box",
+  display: "inline-flex",
+  justifyContent: "center",
+  textDecorationLine: "none",
+  verticalAlign: "middle",
+  margin: "0px",
+  overflow: "hidden",
+  fontFamily: vars.fontFamilyBase,
+  outlineStyle: "none",
+  padding: `5px ${vars.spacingHorizontalM}`,
+  borderRadius: vars.borderRadiusMedium,
+  fontSize: vars.fontSizeBase300,
+  fontWeight: vars.fontWeightSemibold,
+  lineHeight: vars.lineHeightBase300,
+  transitionDuration: vars.durationFaster,
+  transitionProperty: "background, border, color",
+  transitionTimingFunction: vars.curveEasyEase,
+
+  selectors: {
+    "&:disabled": {
+      cursor: "not-allowed",
+    },
+
+    [`&:not(${iconOnlyStyle})`]: {
+      minWidth: "96px",
     },
   },
 });

--- a/packages/components/button/Button.tsx
+++ b/packages/components/button/Button.tsx
@@ -2,7 +2,7 @@ import { mergeProps, createMemo, children } from "solid-js";
 import type { ButtonProps } from "./Button.types";
 import { button } from "./Button.css";
 
-const Button = (props: ButtonProps) => {
+export const Button = (props: ButtonProps) => {
   const merged = mergeProps(
     { type: "button", appearance: "secondary" as ButtonProps["appearance"] },
     props,
@@ -86,5 +86,3 @@ const Button = (props: ButtonProps) => {
     </button>
   );
 };
-
-export default Button;

--- a/packages/components/button/index.ts
+++ b/packages/components/button/index.ts
@@ -1,2 +1,2 @@
-export { default as Button } from "./Button";
+export { Button as default } from "./Button";
 export * from "./Button.types";

--- a/packages/components/card/Card/Card.tsx
+++ b/packages/components/card/Card/Card.tsx
@@ -154,5 +154,3 @@ export const Card = (props: CardProps) => {
     </div>
   );
 };
-
-export default Card;

--- a/packages/components/card/Card/index.ts
+++ b/packages/components/card/Card/index.ts
@@ -1,2 +1,2 @@
-export { default as Card } from "./Card";
+export { Card as default } from "./Card";
 export type { CardProps } from "./Card.types";

--- a/packages/components/card/CardFooter/CardFooter.tsx
+++ b/packages/components/card/CardFooter/CardFooter.tsx
@@ -20,5 +20,3 @@ export const CardFooter = (
     </div>
   );
 };
-
-export default CardFooter;

--- a/packages/components/card/CardFooter/index.tsx
+++ b/packages/components/card/CardFooter/index.tsx
@@ -1,2 +1,2 @@
-export { default as CardFooter } from "./CardFooter";
+export { CardFooter as default } from "./CardFooter";
 export type { CardFooterProps } from "./CardFooter.types";

--- a/packages/components/card/CardHeader/CardHeader.tsx
+++ b/packages/components/card/CardHeader/CardHeader.tsx
@@ -43,5 +43,3 @@ export const CardHeader = (props: CardHeaderProps) => {
     </div>
   );
 };
-
-export default CardHeader;

--- a/packages/components/card/CardHeader/index.ts
+++ b/packages/components/card/CardHeader/index.ts
@@ -1,2 +1,2 @@
-export { default as CardHeader } from "./CardHeader";
+export { CardHeader as default } from "./CardHeader";
 export type { CardHeaderProps } from "./CardHeader.types";

--- a/packages/components/card/CardPreview/CardPreview.tsx
+++ b/packages/components/card/CardPreview/CardPreview.tsx
@@ -3,7 +3,7 @@ import { splitProps, children } from "solid-js";
 import type { CardPreviewProps } from "./CardPreview.types";
 import { cardPreview, logo } from "./CardPreview.css";
 
-const CardPreview = (props: CardPreviewProps) => {
+export const CardPreview = (props: CardPreviewProps) => {
   const classList = () => ({
     [cardPreview]: true,
     [props.class || ""]: !!props.class,
@@ -22,5 +22,3 @@ const CardPreview = (props: CardPreviewProps) => {
     </div>
   );
 };
-
-export default CardPreview;

--- a/packages/components/card/CardPreview/index.ts
+++ b/packages/components/card/CardPreview/index.ts
@@ -1,2 +1,2 @@
-export { default as CardPreview } from "./CardPreview";
+export { CardPreview as default } from "./CardPreview";
 export type { CardPreviewProps } from "./CardPreview.types";

--- a/packages/components/card/index.ts
+++ b/packages/components/card/index.ts
@@ -1,7 +1,7 @@
-export { Card } from "./Card";
-export { CardFooter } from "./CardFooter";
-export { CardHeader } from "./CardHeader";
-export { CardPreview } from "./CardPreview";
+export { default as Card } from "./Card";
+export { default as CardFooter } from "./CardFooter";
+export { default as CardHeader } from "./CardHeader";
+export { default as CardPreview } from "./CardPreview";
 
 export type { CardProps } from "./Card/Card.types";
 export type { CardFooterProps } from "./CardFooter/CardFooter.types";

--- a/packages/components/checkbox/Checkbox.tsx
+++ b/packages/components/checkbox/Checkbox.tsx
@@ -1,11 +1,15 @@
-import { createSignal, mergeProps, Show } from "solid-js";
+import { createSignal, lazy, mergeProps, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
 
 import { FaSolidCheck } from "solid-icons/fa";
 
 import type { CheckboxProps, RequiredCheckboxProps } from "./Checkbox.types";
 
+import type { LabelProps } from "../label";
+
 import * as styles from "./Checkbox.css";
+
+const Label = lazy(() => import("../label"));
 
 export const Checkbox = (props: CheckboxProps) => {
   const merged = mergeProps(
@@ -67,7 +71,17 @@ export const Checkbox = (props: CheckboxProps) => {
       />
 
       <Show when={merged.labelPosition === "before" && merged.label}>
-        <Dynamic component={merged.label} classList={labelClassList()} />
+        <Show
+          when={typeof merged.label !== "string"}
+          fallback={
+            <Label classList={labelClassList()}>{merged.label as string}</Label>
+          }
+        >
+          <Label
+            classList={labelClassList()}
+            {...(merged.label as LabelProps)}
+          />
+        </Show>
       </Show>
 
       <Dynamic
@@ -82,7 +96,17 @@ export const Checkbox = (props: CheckboxProps) => {
       </Dynamic>
 
       <Show when={merged.labelPosition === "after" && merged.label}>
-        <Dynamic component={merged.label} classList={labelClassList()} />
+        <Show
+          when={typeof merged.label !== "string"}
+          fallback={
+            <Label classList={labelClassList()}>{merged.label as string}</Label>
+          }
+        >
+          <Label
+            classList={labelClassList()}
+            {...(merged.label as LabelProps)}
+          />
+        </Show>
       </Show>
     </span>
   );

--- a/packages/components/checkbox/Checkbox.types.ts
+++ b/packages/components/checkbox/Checkbox.types.ts
@@ -1,11 +1,11 @@
 import type { HTMLElementProps, RequiredPick } from "~/types";
-import type { Label } from "../label";
+import type { LabelProps } from "../label";
 
 export interface CheckboxSlots extends HTMLElementProps<"span"> {
   /**
    * The Checkbox's label.
    */
-  label?: typeof Label;
+  label?: string | LabelProps;
 
   /**
    * Hidden input that handles the checkbox's functionality.

--- a/packages/components/checkbox/index.ts
+++ b/packages/components/checkbox/index.ts
@@ -1,2 +1,2 @@
-export { Checkbox } from "./Checkbox";
+export { Checkbox as default } from "./Checkbox";
 export type { CheckboxProps } from "./Checkbox.types";

--- a/packages/components/divider/Divider.tsx
+++ b/packages/components/divider/Divider.tsx
@@ -2,7 +2,7 @@ import { mergeProps, Show } from "solid-js";
 import type { DividerAlignment, DividerProps } from "./Divider.types";
 import { divider } from "./Divider.css";
 
-const Divider = (props: DividerProps) => {
+export const Divider = (props: DividerProps) => {
   const merged = mergeProps(
     { alignContent: "center" as DividerAlignment },
     props,
@@ -49,5 +49,3 @@ const Divider = (props: DividerProps) => {
     </div>
   );
 };
-
-export default Divider;

--- a/packages/components/divider/index.ts
+++ b/packages/components/divider/index.ts
@@ -1,2 +1,2 @@
-export { default as Divider } from "./Divider";
+export { Divider as default } from "./Divider";
 export * from "./Divider.types";

--- a/packages/components/field/Field.tsx
+++ b/packages/components/field/Field.tsx
@@ -11,7 +11,7 @@ import type { FieldProps } from "./Field.types";
 
 import * as styles from "./Field.css";
 
-const Label = lazy(() => import("../label/Label"));
+const Label = lazy(() => import("../label"));
 
 type RequiredProps<T extends keyof FieldProps> = NonNullable<FieldProps[T]>;
 

--- a/packages/components/field/index.ts
+++ b/packages/components/field/index.ts
@@ -1,2 +1,2 @@
-export { Field } from "./Field";
+export { Field as default } from "./Field";
 export type { FieldProps } from "./Field.types";

--- a/packages/components/input/Input.tsx
+++ b/packages/components/input/Input.tsx
@@ -2,7 +2,7 @@ import { children, createSignal, mergeProps, splitProps } from "solid-js";
 import type { InputProps } from "./Input.types";
 import { input } from "./Input.css";
 
-const Input = (props: InputProps) => {
+export const Input = (props: InputProps) => {
   const merged = mergeProps({ type: "text" as InputProps["type"] }, props);
 
   const [local, others] = splitProps(merged, [
@@ -105,5 +105,3 @@ const Input = (props: InputProps) => {
     </span>
   );
 };
-
-export default Input;

--- a/packages/components/input/index.ts
+++ b/packages/components/input/index.ts
@@ -1,2 +1,2 @@
-export { default as Input } from "./Input";
+export { Input as default } from "./Input";
 export * from "./Input.types";

--- a/packages/components/label/Label.tsx
+++ b/packages/components/label/Label.tsx
@@ -2,7 +2,7 @@ import { mergeProps, children } from "solid-js";
 import type { LabelProps } from "./Label.types";
 import { label } from "./Label.css";
 
-const Label = (props: LabelProps) => {
+export const Label = (props: LabelProps) => {
   const merged = mergeProps(
     {
       size: "medium" as NonNullable<LabelProps["size"]>,
@@ -44,12 +44,10 @@ const Label = (props: LabelProps) => {
   );
 
   return (
-    // biome-ignore lint/a11y/noLabelWithoutControl:
+    // biome-ignore lint/a11y/noLabelWithoutControl: We know this is a label, not a control
     <label classList={classList()} style={merged.style}>
       {merged.children}
       {required()}
     </label>
   );
 };
-
-export default Label;

--- a/packages/components/label/index.ts
+++ b/packages/components/label/index.ts
@@ -1,2 +1,2 @@
-export { default as Label } from "./Label";
+export { Label as default } from "./Label";
 export * from "./Label.types";

--- a/packages/components/link/index.ts
+++ b/packages/components/link/index.ts
@@ -1,2 +1,2 @@
-export { Link } from "./Link";
+export { Link as default } from "./Link";
 export type { LinkProps } from "./Link.types";

--- a/packages/components/progress/Progress.tsx
+++ b/packages/components/progress/Progress.tsx
@@ -8,7 +8,7 @@ import type {
 import { progress } from "./Progress.css";
 import { clampValue } from "~/utils/clampValue";
 
-const ProgressBar = (props: ProgressBarProps) => {
+export const ProgressBar = (props: ProgressBarProps) => {
   const merged = mergeProps(
     {
       max: 100,
@@ -63,5 +63,3 @@ const ProgressBar = (props: ProgressBarProps) => {
     </div>
   );
 };
-
-export default ProgressBar;

--- a/packages/components/progress/index.ts
+++ b/packages/components/progress/index.ts
@@ -1,2 +1,2 @@
-export { default as ProgressBar } from "./Progress";
+export { ProgressBar as default } from "./Progress";
 export * from "./Progress.types";

--- a/packages/components/slider/Slider.tsx
+++ b/packages/components/slider/Slider.tsx
@@ -9,7 +9,7 @@ import {
 import { clamp } from "~/utils/clamp";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
 
-const Slider = (props: SliderProps) => {
+export const Slider = (props: SliderProps) => {
   const merged = mergeProps(
     { min: 0, max: 100, size: "medium" as SliderSize },
     props,
@@ -80,5 +80,3 @@ const Slider = (props: SliderProps) => {
 const getPercent = (value: number, min: number, max: number) => {
   return max === min ? 0 : ((value - min) / (max - min)) * 100;
 };
-
-export default Slider;

--- a/packages/components/slider/index.ts
+++ b/packages/components/slider/index.ts
@@ -1,2 +1,2 @@
-export { default as Slider } from "./Slider";
+export { Slider as default } from "./Slider";
 export * from "./Slider.types";

--- a/packages/components/spinner/Spinner.tsx
+++ b/packages/components/spinner/Spinner.tsx
@@ -2,9 +2,9 @@ import { children, lazy, mergeProps, Show } from "solid-js";
 import type { SpinnerProps } from "./Spinner.types";
 import { spinner } from "./Spinner.css";
 
-const LazyLabel = lazy(() => import("~/components/label/Label"));
+const LazyLabel = lazy(() => import("~/components/label"));
 
-const Spinner = (props: SpinnerProps) => {
+export const Spinner = (props: SpinnerProps) => {
   const merged = mergeProps(
     { size: "medium" as NonNullable<SpinnerProps["size"]> },
     props,
@@ -66,5 +66,3 @@ const Spinner = (props: SpinnerProps) => {
     </div>
   );
 };
-
-export default Spinner;

--- a/packages/components/spinner/index.ts
+++ b/packages/components/spinner/index.ts
@@ -1,2 +1,2 @@
-export { default as Spinner } from "./Spinner";
+export { Spinner as default } from "./Spinner";
 export * from "./Spinner.types";

--- a/packages/components/switch/Switch.tsx
+++ b/packages/components/switch/Switch.tsx
@@ -3,9 +3,9 @@ import { children, createSignal, lazy, mergeProps } from "solid-js";
 import type { SwitchProps } from "./Switch.types";
 import { switchStyles } from "./Switch.css";
 
-const LazyLabel = lazy(() => import("~/components/label/Label"));
+const LazyLabel = lazy(() => import("~/components/label"));
 
-const Switch = (props: SwitchProps) => {
+export const Switch = (props: SwitchProps) => {
   const merged = mergeProps(
     {
       indicator: <Indicator />,
@@ -97,5 +97,3 @@ const Switch = (props: SwitchProps) => {
 };
 
 const Indicator = () => <div class={switchStyles.defaultIndicator} />;
-
-export default Switch;

--- a/packages/components/switch/index.ts
+++ b/packages/components/switch/index.ts
@@ -1,2 +1,2 @@
-export { default as Switch } from "./Switch";
+export { Switch as default } from "./Switch";
 export * from "./Switch.types";

--- a/packages/components/text/Body1.ts
+++ b/packages/components/text/Body1.ts
@@ -1,1 +1,1 @@
-export { Body1 } from "./presets/Body1/Body1";
+export { Body1 as default } from "./presets/Body1/Body1";

--- a/packages/components/text/Caption1.ts
+++ b/packages/components/text/Caption1.ts
@@ -1,1 +1,1 @@
-export { Caption1 } from "./presets/Caption1/Caption1";
+export { Caption1 as default } from "./presets/Caption1/Caption1";

--- a/packages/components/text/Subtitle1.ts
+++ b/packages/components/text/Subtitle1.ts
@@ -1,1 +1,1 @@
-export { Subtitle1 } from "./presets/Subtitle1/Subtitle1";
+export { Subtitle1 as default } from "./presets/Subtitle1/Subtitle1";

--- a/packages/components/text/Text/Text.tsx
+++ b/packages/components/text/Text/Text.tsx
@@ -5,7 +5,7 @@ import type { RequiredTextProps, TextProps } from "./Text.types";
 import * as styles from "./Text.css";
 import { Dynamic } from "solid-js/web";
 
-const Text = (props: TextProps) => {
+export const Text = (props: TextProps) => {
   const merged = mergeProps(
     {
       as: "span",
@@ -59,5 +59,3 @@ const Text = (props: TextProps) => {
 
   return <Dynamic component={local.as} {...others} classList={classList()} />;
 };
-
-export default Text;

--- a/packages/components/text/Text/index.ts
+++ b/packages/components/text/Text/index.ts
@@ -1,2 +1,2 @@
-export { default as Text } from "./Text";
+export { Text as default } from "./Text";
 export type { TextProps } from "./Text.types";

--- a/packages/components/text/index.ts
+++ b/packages/components/text/index.ts
@@ -1,6 +1,6 @@
-export { Body1 } from "./Body1";
-export { Caption1 } from "./Caption1";
-export { Subtitle1 } from "./Subtitle1";
+export { default as Body1 } from "./Body1";
+export { default as Caption1 } from "./Caption1";
+export { default as Subtitle1 } from "./Subtitle1";
 
-export { Text } from "./Text";
+export { default as Text } from "./Text";
 export type { TextProps } from "./Text";

--- a/packages/components/text/presets/createPreset.tsx
+++ b/packages/components/text/presets/createPreset.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "solid-js";
 import type { TextPresetProps } from "../Text/Text.types";
 
-const Text = lazy(() => import("../Text/Text"));
+const Text = lazy(() => import("../Text"));
 
 export const createPreset = (
   classList:

--- a/packages/components/textarea/Textarea.tsx
+++ b/packages/components/textarea/Textarea.tsx
@@ -8,7 +8,7 @@ type RequiredProps<T extends keyof TextareaProps> = NonNullable<
   TextareaProps[T]
 >;
 
-const Textarea = (props: TextareaProps) => {
+export const Textarea = (props: TextareaProps) => {
   const [value, setValue] = createSignal(props.value ?? props.defaultValue);
 
   const merged = mergeProps(
@@ -69,5 +69,3 @@ const Textarea = (props: TextareaProps) => {
     </span>
   );
 };
-
-export default Textarea;

--- a/packages/components/textarea/index.ts
+++ b/packages/components/textarea/index.ts
@@ -1,4 +1,2 @@
-import Textarea from "./Textarea";
-
-export { Textarea };
+export { Textarea as default } from "./Textarea";
 export type { TextareaProps } from "./Textarea.types";

--- a/packages/components/toast/ToastContainer/ToastContainer.tsx
+++ b/packages/components/toast/ToastContainer/ToastContainer.tsx
@@ -6,7 +6,7 @@ import { toastContainerStyle } from "./ToastContainer.css";
 /**
  * Toast container component - Manages toast position and animation effects
  */
-const ToastContainer: Component<ToastContainerProps> = (props) => {
+export const ToastContainer: Component<ToastContainerProps> = (props) => {
   return (
     <Portal
       ref={(el) => {
@@ -18,5 +18,3 @@ const ToastContainer: Component<ToastContainerProps> = (props) => {
     </Portal>
   );
 };
-
-export default ToastContainer;

--- a/packages/components/toast/ToastContainer/index.ts
+++ b/packages/components/toast/ToastContainer/index.ts
@@ -1,2 +1,2 @@
-export { default as ToastContainer } from "./ToastContainer";
+export { ToastContainer as default } from "./ToastContainer";
 export * from "./ToastContainer.types";

--- a/packages/components/toast/ToastContent/ToastContent.tsx
+++ b/packages/components/toast/ToastContent/ToastContent.tsx
@@ -13,7 +13,7 @@ import { VsClose } from "solid-icons/vs";
 
 import { usePausableTimeout } from "~/hooks";
 
-import { ToastIcon } from "../ToastIcon";
+import ToastIcon from "../ToastIcon";
 import type {
   ToastContentProps,
   ToastPosition,
@@ -24,12 +24,12 @@ import { useToast } from "../ToastContext/ToastContext";
 import * as styles from "./ToastContent.css";
 import { toastMaxWidth } from "./ToastContent.css";
 
-const Button = lazy(() => import("~/components/button/Button"));
+const Button = lazy(() => import("~/components/button"));
 
 /**
  * Toast content component - Renders toast content including icon, message and action buttons
  */
-const ToastContent: Component<ToastContentProps> = (props) => {
+export const ToastContent: Component<ToastContentProps> = (props) => {
   const { removeToast } = useToast();
 
   const merged = mergeProps(
@@ -194,5 +194,3 @@ const getTypeClass = (type: ToastType) => {
       return styles.toastInfo;
   }
 };
-
-export default ToastContent;

--- a/packages/components/toast/ToastContent/index.ts
+++ b/packages/components/toast/ToastContent/index.ts
@@ -1,4 +1,2 @@
-import ToastContent from "./ToastContent";
-
-export default ToastContent;
+export { ToastContent as default } from "./ToastContent";
 export * from "./ToastContent.types";

--- a/packages/components/toast/ToastContext/ToastContext.tsx
+++ b/packages/components/toast/ToastContext/ToastContext.tsx
@@ -11,11 +11,9 @@ import type {
   ToastContext as Context,
   ToastOptions,
 } from "./ToastContext.types";
-import ToastContent, {
-  type ToastContentProps,
-  type ToastPosition,
-} from "../ToastContent";
-import { ToastContainer } from "../ToastContainer";
+import type { ToastContentProps, ToastPosition } from "../ToastContent";
+import { ToastContent } from "../ToastContent/ToastContent";
+import { ToastContainer } from "../ToastContainer/ToastContainer";
 
 const ToastContext = createContext<Context>();
 

--- a/packages/components/toast/ToastIcon/ToastIcon.tsx
+++ b/packages/components/toast/ToastIcon/ToastIcon.tsx
@@ -11,7 +11,7 @@ import { toastIconStyle } from "./ToastIcon.css";
 /**
  * Toast icon component - displays corresponding icon based on Toast type
  */
-const ToastIcon: Component<ToastIconProps> = (props) => {
+export const ToastIcon: Component<ToastIconProps> = (props) => {
   const iconMap = {
     info: <AiFillInfoCircle />,
     success: <AiFillCheckCircle />,
@@ -21,5 +21,3 @@ const ToastIcon: Component<ToastIconProps> = (props) => {
 
   return <span class={toastIconStyle[props.type]}>{iconMap[props.type]}</span>;
 };
-
-export default ToastIcon;

--- a/packages/components/toast/ToastIcon/index.ts
+++ b/packages/components/toast/ToastIcon/index.ts
@@ -1,2 +1,2 @@
-export { default as ToastIcon } from "./ToastIcon";
+export { ToastIcon as default } from "./ToastIcon";
 export * from "./ToastIcon.types";

--- a/packages/components/toast/index.ts
+++ b/packages/components/toast/index.ts
@@ -5,10 +5,10 @@ export type {
   ToastType,
 } from "./ToastContent";
 
-export { ToastContainer } from "./ToastContainer";
+export { default as ToastContainer } from "./ToastContainer";
 export type { ToastContainerProps } from "./ToastContainer";
 
-export { ToastIcon } from "./ToastIcon";
+export { default as ToastIcon } from "./ToastIcon";
 export type { ToastIconProps } from "./ToastIcon";
 
 export { ToastProvider, useToast } from "./ToastContext/ToastContext";

--- a/packages/components/tooltip/Tooltip.tsx
+++ b/packages/components/tooltip/Tooltip.tsx
@@ -13,7 +13,7 @@ import { useTimeout } from "~/hooks/useTimeout";
 import { calculateOffsets, type OffsetNullable } from "./position";
 import { createSignal } from "solid-js";
 
-const Tooltip = (props: TooltipProps) => {
+export const Tooltip = (props: TooltipProps) => {
   let tooltipRef: HTMLDivElement | undefined;
   let triggerRef: HTMLElement | undefined;
 
@@ -212,5 +212,3 @@ const Tooltip = (props: TooltipProps) => {
     </>
   );
 };
-
-export default Tooltip;

--- a/packages/components/tooltip/index.ts
+++ b/packages/components/tooltip/index.ts
@@ -1,2 +1,2 @@
-export { default as Tooltip } from "./Tooltip";
+export { Tooltip as default } from "./Tooltip";
 export * from "./Tooltip.types";

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,16 +1,19 @@
 export * from "~/themes";
 
-export { Button, type ButtonProps } from "~/components/button";
-export { Label, type LabelProps } from "~/components/label";
-export { Spinner, type SpinnerProps } from "~/components/spinner";
-export { Switch, type SwitchProps } from "~/components/switch";
-export { Divider, type DividerProps } from "~/components/divider";
-export { ProgressBar, type ProgressBarProps } from "~/components/progress";
-export { Badge, type BadgeProps } from "~/components/badge";
-export { Tooltip, type TooltipProps } from "~/components/tooltip";
-export { Input, type InputProps } from "~/components/input";
-export { Slider, type SliderProps } from "~/components/slider";
-export { Textarea, type TextareaProps } from "~/components/textarea";
+export { default as Button, type ButtonProps } from "~/components/button";
+export { default as Label, type LabelProps } from "~/components/label";
+export { default as Spinner, type SpinnerProps } from "~/components/spinner";
+export { default as Switch, type SwitchProps } from "~/components/switch";
+export { default as Divider, type DividerProps } from "~/components/divider";
+export {
+  default as ProgressBar,
+  type ProgressBarProps,
+} from "~/components/progress";
+export { default as Badge, type BadgeProps } from "~/components/badge";
+export { default as Tooltip, type TooltipProps } from "~/components/tooltip";
+export { default as Input, type InputProps } from "~/components/input";
+export { default as Slider, type SliderProps } from "~/components/slider";
+export { default as Textarea, type TextareaProps } from "~/components/textarea";
 export { Card, CardFooter, CardHeader, CardPreview } from "~/components/card";
 export type {
   CardProps,
@@ -18,9 +21,9 @@ export type {
   CardHeaderProps,
   CardPreviewProps,
 } from "~/components/card";
-export { Link, type LinkProps } from "~/components/link";
-export { Checkbox, type CheckboxProps } from "~/components/checkbox";
-export { Field, type FieldProps } from "~/components/field";
+export { default as Link, type LinkProps } from "~/components/link";
+export { default as Checkbox, type CheckboxProps } from "~/components/checkbox";
+export { default as Field, type FieldProps } from "~/components/field";
 
 export { ToastProvider, useToast } from "~/components/toast";
 


### PR DESCRIPTION
重构组件导出方式，将命名导出改为默认导出以保持一致性
移除组件文件中的冗余默认导出语句
优化类型定义，如将Label组件类型从实例类型改为Props类型
调整部分组件的导入路径以简化代码
更新index.ts文件以反映导出方式的变化