### PR TITLE
ci(github-actions): remove npm publish step from version bump workflow

### DIFF
--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -117,7 +117,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Remove npm ci and npm publish steps from the workflow
- This change prevents the action from being triggered indefinitely