### PR TITLE
ci(bump-new-version): add npm registry url for node setup

### DIFF
--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -96,6 +96,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          registry-url: https://registry.npmjs.org/
 
       - uses: oven-sh/setup-bun@v1
         with:


### PR DESCRIPTION
- Add registry-url for npm in actions/setup-node@v4
- This change ensures the correct registry is used during package installation