### PR TITLE
ci: fix release_id reference in publish-release job

### DIFF
--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -126,7 +126,7 @@ jobs:
         id: publish-release
         uses: actions/github-script@v7
         env:
-          release_id: ${{ needs.create-release-branch.outputs.release_id }}
+          release_id: ${{ needs.create-release.outputs.release_id }}
         with:
           script: |
             github.rest.repos.updateRelease({


### PR DESCRIPTION
- Update the release_id reference from create-release-branch to create-release
- This change ensures that the correct release ID is used in the publish-release job